### PR TITLE
fix(setup): missing module in distribution package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy >=1.21.0",
-    "pygame==2.1.0",
+    "pygame>=2.1.0",
 ]
 dynamic = ["version"]
 

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ class CMakeBuild(build_ext):
 setuptools.setup(
     name="magent2",
     version=get_version(),
+    packages=setuptools.find_packages(),
     ext_modules=[CMakeExtension("magent2.libmagent", ".", [])],
     cmdclass={"build_ext": CMakeBuild},
 )


### PR DESCRIPTION
This commit fixes an issue where the code was not being included in the distribution package.

The issue was resolved by adding a line to the setup.py to include the modules.

With this change, the package can now be installed and used as intended.

Relate to: #14 