### PR TITLE
Add pettingzoo as dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "numpy >=1.21.0",
     "pygame>=2.1.0",
+    "pettingzoo>=1.23.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
I looked through the codebase and didn't see this anywhere as a requirement, but there's multiple env files which have calls to things like `aec_to_parallel` and I don't imagine those would work unless the end user happens to have pettingzoo installed independently. What we really need is some basic pytest stuff and better CI to catch these kinds of issues, but this I think should suffice for now. Note that gymnasium is required in pettingzoo, so it doesn't need to be specified as a dependency here (easier to make sure that the pettingzoo version is up to date at least, and let pettingzoo keep up to date with gymnasium itself internally)