### PR TITLE
Fix(render): fix banner problem with number of handles

### DIFF
--- a/magent2/render.py
+++ b/magent2/render.py
@@ -136,7 +136,7 @@ class Renderer:
 
         if len(self.handles) == 1:
             result = [(form_txt(0),)]
-        if len(self.handles) == 2:
+        elif len(self.handles) == 2:
             vs = " vs ", (0, 0, 0)
             result = [(form_txt(0), vs, form_txt(1))]
         elif len(self.handles) == 4:


### PR DESCRIPTION
This code fix an issue related to the render of the banners.

While using different groups of agents (so different handles) the system was crashing, only the condition with 2 handles was working correctly.

With this change it's allowed to use also a group of 1 or 4 handles.