### PR TITLE
Update workflows to build Python 3.11 wheels, and drop Python 3.7 support

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,9 +21,6 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          python: 37
-          platform: manylinux_x86_64
-        - os: ubuntu-latest
           python: 38
           platform: manylinux_x86_64
         - os: ubuntu-latest
@@ -32,9 +29,12 @@ jobs:
         - os: ubuntu-latest
           python: 310
           platform: manylinux_x86_64
+        - os: ubuntu-latest
+          python: 311
+          platform: manylinux_x86_64
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.6.0
       env:
@@ -49,7 +49,7 @@ jobs:
   build-src:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build src
       run: |
         python -m pip install --upgrade pip
@@ -64,12 +64,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         include:
         - os: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v3
@@ -99,7 +99,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
     - name: Download dists
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: dist

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -20,29 +20,30 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           python: 38
           platform: manylinux_x86_64
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           python: 39
           platform: manylinux_x86_64
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           python: 310
           platform: manylinux_x86_64
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           python: 311
           platform: manylinux_x86_64
 
     steps:
     - uses: actions/checkout@v4
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.6.0
+      uses: pypa/cibuildwheel@v2.19.2
       env:
         CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform }}
-        CIBW_ARCHS: all
+        CIBW_ARCHS: auto
         CIBW_BUILD_VERBOSITY: 1
+
     - name: Store wheels
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl
 
@@ -56,7 +57,7 @@ jobs:
         pip install wheel
         python setup.py sdist
     - name: Store src
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: dist/*.tar.gz
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - run: pip install pre-commit
       - run: pre-commit --version
       - run: pre-commit install

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install using pip: `pip install magent2`. See [docs](https://magent2.farama.org/
 
 
 ## Requirements
-MAgent2 supports Linux and macOS and Python 3.7+.
+MAgent2 supports Linux and macOS and Python 3.8+.
 
 ## References
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "magent2"
 description = "Multi-Agent Reinforcement Learning environments with very large numbers of agents."
 readme = "README.md"
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI"]
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 4 - Beta",  # change to `5 - Production/Stable` when ready
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Also, I updated versions of some actions because the ones used are already deprecated.