### PR TITLE
Downgrade pettingzoo version due broken API call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.21.0,<2.0",
     "pygame>=2.1.0",
-    "pettingzoo>=1.23.1",
+    "pettingzoo>=1.22.3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.21.0,<2.0",
     "pygame>=2.1.0",
-    "pettingzoo>=1.22.3",
+    "pettingzoo<=1.22.3",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Downgrade PettingZoo to 1.22.3 for MAgent2 compatibility.

Related issues #31 and #44.