### PR TITLE
Fixed broken restart compatibility with the PettingZoo API

### DIFF
--- a/magent2/environments/magent_env.py
+++ b/magent2/environments/magent_env.py
@@ -165,7 +165,7 @@ class magent_parallel_env(ParallelEnv):
         self.frames = 0
         self.team_sizes = [self.env.get_num(handle) for handle in self.handles]
         self.generate_map()
-        return self._compute_observations()
+        return self._compute_observations(), {agent: {} for agent in self.agents}
 
     def _compute_observations(self):
         observes = [None] * self.max_num_agents


### PR DESCRIPTION
The `env.reset()` method does not follow the Gymnasium and therefore PettingZoo migration guide, it was expected to return the initial observation + information and it only returns the initial observation.

Related issues:  #31.