### PR TITLE
Change in screen resolution

### DIFF
--- a/magent2/render.py
+++ b/magent2/render.py
@@ -92,7 +92,7 @@ class Renderer:
         self.env = env
         self.mode = mode
         self.handles = self.env.get_handles()
-        base_resolution = (map_size * 8, map_size * 8 + 15)
+        base_resolution = (map_size * 8, map_size * 8 + 16)
         if mode == "human":
             pygame.init()
             pygame.display.init()


### PR DESCRIPTION
As I mentioned in #47, I am working on integrating MAgent2 into BenchMARL, however, I encountered a bug while rendering the video during test time. When `torchrl` tries to encode the mp4 video from a set of frames using the libx264 codec, it throws the error `height not divisible by 2`.

The easiest way to solve it is to simply increase the height by one pixel in MAgent2.

cc: @atstarke 