### PR TITLE
Fix local installation

### DIFF
--- a/magent2/c_lib.py
+++ b/magent2/c_lib.py
@@ -10,11 +10,17 @@ import platform
 def _load_lib():
     """Load library in local."""
     cur_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    lib_path = os.path.join(cur_path, "..", "venv", "Lib", "site-packages", "magent2")
+    lib_path = cur_path
     if platform.system() == "Darwin":
-        path_to_so_file = os.path.join(lib_path, "libmagent.dylib")
+        import sysconfig
+
+        filename = f"libmagent.{sysconfig.get_config_var('SOABI')}.dylib"
+        path_to_so_file = os.path.join(lib_path, filename)
     elif platform.system() == "Linux":
-        path_to_so_file = os.path.join(lib_path, "libmagent.so")
+        import sysconfig
+
+        filename = f"libmagent.{sysconfig.get_config_var('SOABI')}.so"
+        path_to_so_file = os.path.join(lib_path, filename)
     elif platform.system() == "Windows":
         path_to_so_file = os.path.join(lib_path, "magent.dll")
     else:


### PR DESCRIPTION
`pip install -e .` was failing.
The previous setup was creating a libmagent.so file, but the build script was looking for a cpython specific library file. This failed because it didn't exist, breaking the build. It then tried to load the libmagent.so file which wasn't correct because it was supposed to use the cpython specific file.

Fixing both of these issues, it now installs with `pip install -e .`
This works on linux, probably works on mac. I have no idea on windows

I do not know if this will package correctly for pip install with pypi