### PR TITLE
Modernize MAgent2 for Python 3.10-3.12 (v0.4.0)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,51 +21,53 @@ jobs:
       matrix:
         include:
         - os: ubuntu-22.04
-          python: 38
-          platform: manylinux_x86_64
-        - os: ubuntu-22.04
-          python: 39
-          platform: manylinux_x86_64
-        - os: ubuntu-22.04
           python: 310
           platform: manylinux_x86_64
         - os: ubuntu-22.04
           python: 311
           platform: manylinux_x86_64
+        - os: ubuntu-22.04
+          python: 312
+          platform: manylinux_x86_64
 
     steps:
     - uses: actions/checkout@v4
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform }}
         CIBW_ARCHS: auto
         CIBW_BUILD_VERBOSITY: 1
 
     - name: Store wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: wheels-linux-${{ matrix.python }}
         path: ./wheelhouse/*.whl
 
   build-src:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
     - name: Build src
       run: |
-        python -m pip install --upgrade pip
-        pip install wheel
-        python setup.py sdist
+        python -m pip install --upgrade pip build
+        python -m build --sdist
     - name: Store src
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: sdist
         path: dist/*.tar.gz
 
   build-wheels-ms:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         include:
         - os: windows-latest
 
@@ -73,7 +75,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
@@ -87,8 +89,9 @@ jobs:
         pip install wheel cmake-build-extension
         pip wheel .  --no-deps -w wheelhouse/
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
+        name: wheels-windows-${{ matrix.python-version }}
         path: ./wheelhouse/*.whl
 
   publish:
@@ -100,10 +103,10 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
     - name: Download dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: artifact
         path: dist
+        merge-multiple: true
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,12 @@ Parallel_Demo.py
 
 # Environments
 .venv
+
+# Build artifacts
+*.pyd
+*.egg-info/
+_frames/
+.pytest_cache/
+
+# Demo outputs
+battle_video.mp4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: v3.3.2
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py310-plus"]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,21 @@ project(magent)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
+# Use CMake's standard mechanism instead of -std=c++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 file(GLOB autopilot_sources src/*.cc src/gridworld/*.cc src/utility/*.cc)
 set(LIB_SRC_FILES ${autopilot_sources})
 
-
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -std=c++11 -O3")
-IF (WIN32)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W0 /wd4711 /wd4710")
-ELSE()
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-reorder -Wno-sign-compare -Wno-missing-braces")
-ENDIF()
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG")
+if(MSVC)
+  add_compile_options(/W0 /wd4711 /wd4710)
+  add_compile_definitions(DEBUG)
+else()
+  add_compile_options(-g -Wall -O3
+    -Wno-unused-variable -Wno-reorder -Wno-sign-compare -Wno-missing-braces)
+  add_compile_definitions(DEBUG)
+endif()
 
 # runtime library
 add_library(magent SHARED ${LIB_SRC_FILES})

--- a/README.md
+++ b/README.md
@@ -11,11 +11,98 @@ MAgent2 is a library for the creation of environments where large numbers of pix
 MAgent2 is a maintained fork of the original [MAgent](https://github.com/geek-ai/MAgent) codebase. It contains some [reference environments](https://github.com/Farama-Foundation/MAgent2/tree/main/magent2/environments) implemented using the [PettingZoo](https://github.com/Farama-Foundation/PettingZoo) API. These environments used to be included in PettingZoo itself, but have been moved here to exist independently. They are being regularly maintained and will receive bug fixes, support new versions of Python, etc. Development used to take place at [github.com/Farama-Foundation/MAgent](https://github.com/Farama-Foundation/MAgent) but was moved to [github.com/Farama-Foundation/MAgent2](https://github.com/Farama-Foundation/MAgent2) so that the distinction from the original MAgent library is clear to users.
 
 ## Installation
-Install using pip: `pip install magent2`. See [docs](https://magent2.farama.org/) for usage information.
 
+Install using pip:
+```bash
+pip install magent2
+```
+
+See [docs](https://magent2.farama.org/) for usage information.
+
+### Build from source
+
+MAgent2 includes a C++ native extension that requires CMake to build:
+
+```bash
+# Prerequisites: Python 3.10+, CMake, C++ compiler (GCC/Clang on Linux, MSVC on Windows)
+git clone https://github.com/Farama-Foundation/MAgent2.git
+cd MAgent2
+pip install -e .
+```
 
 ## Requirements
-MAgent2 supports Linux and macOS and Python 3.8+.
+
+- Python 3.10+
+- Linux or Windows
+- Dependencies (installed automatically):
+  - `numpy >= 1.21.0`
+  - `pygame >= 2.1.0`
+  - `pettingzoo >= 1.23.1` (which pulls in `gymnasium`)
+
+### Tested with
+
+| Package | Version |
+|---------|---------|
+| Python | 3.11 |
+| numpy | 2.3.x |
+| gymnasium | 1.2.3 |
+| pettingzoo | 1.25.0 |
+| pygame | 2.6.1 |
+
+## Quick Start
+
+### AEC API (agents take turns)
+
+```python
+from magent2.environments import battle_v4
+
+env = battle_v4.env(map_size=45, max_cycles=300)
+env.reset()
+
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+    if termination or truncation:
+        action = None
+    else:
+        action = env.action_space(agent).sample()  # random policy
+    env.step(action)
+
+env.close()
+```
+
+### Parallel API (all agents act simultaneously, faster)
+
+```python
+from magent2.environments.battle.battle import parallel_env
+
+env = parallel_env(map_size=45, max_cycles=300)
+observations, infos = env.reset()
+
+while env.agents:
+    actions = {agent: env.action_space(agent).sample() for agent in env.agents}
+    observations, rewards, terminations, truncations, infos = env.step(actions)
+
+env.close()
+```
+
+### Generate a battle video (requires ffmpeg)
+
+```python
+python battle_video.py
+```
+
+This renders each frame as a grid image (red = red team, blue = blue team) and encodes them into an MP4 video using ffmpeg. See `battle_video.py` for the full implementation.
+
+## Available Environments
+
+| Environment | Agents | Description |
+|-------------|--------|-------------|
+| `battle_v4` | 162 | Two teams battle on a 45x45 grid |
+| `adversarial_pursuit_v4` | 75 | Predators chase prey agents |
+| `battlefield_v5` | 162 | Large battlefield with obstacles |
+| `combined_arms_v6` | 162 | Two unit types per team (melee + ranged) |
+| `gather_v5` | 495 | Agents gather food while avoiding predators |
+| `tiger_deer_v4` | 121 | Tigers hunt deer |
 
 ## References
 ```

--- a/battle_demo.py
+++ b/battle_demo.py
@@ -1,0 +1,66 @@
+"""MAgent2 Battle 环境演示脚本
+
+两队智能体（红队 red vs 蓝队 blue）在 45x45 网格上进行团战。
+使用随机策略运行，输出每步的存活数量和最终结果。
+"""
+
+from magent2.environments import battle_v4
+
+
+def run_battle_demo():
+    # 创建环境 (AEC 模式，即逐个智能体轮流行动)
+    env = battle_v4.env(map_size=45, max_cycles=300)
+    env.reset()
+
+    red_alive = 0
+    blue_alive = 0
+    step_count = 0
+
+    # 统计初始数量
+    for agent in env.agents:
+        if agent.startswith("red"):
+            red_alive += 1
+        else:
+            blue_alive += 1
+    print(f"=== MAgent2 Battle Demo ===")
+    print(f"Initial: red={red_alive}, blue={blue_alive}, total={red_alive + blue_alive}")
+    print()
+
+    # 主循环：逐个智能体行动
+    for agent in env.agent_iter():
+        observation, reward, termination, truncation, info = env.last()
+
+        if termination or truncation:
+            action = None  # 已死亡或截断的智能体不行动
+        else:
+            # 随机选择一个合法动作
+            action = env.action_space(agent).sample()
+
+        env.step(action)
+        step_count += 1
+
+        # 每 1000 步打印一次状态
+        if step_count % 1000 == 0:
+            red = sum(1 for a in env.agents if a.startswith("red"))
+            blue = sum(1 for a in env.agents if a.startswith("blue"))
+            print(f"  step {step_count:>6d}: red={red:>3d}, blue={blue:>3d}")
+
+    # 最终结果
+    red_final = sum(1 for a in env.agents if a.startswith("red"))
+    blue_final = sum(1 for a in env.agents if a.startswith("blue"))
+    print()
+    print(f"=== Battle Finished ===")
+    print(f"Total steps: {step_count}")
+    print(f"Survivors: red={red_final}, blue={blue_final}")
+    if red_final > blue_final:
+        print("Result: Red team wins!")
+    elif blue_final > red_final:
+        print("Result: Blue team wins!")
+    else:
+        print("Result: Draw!")
+
+    env.close()
+
+
+if __name__ == "__main__":
+    run_battle_demo()

--- a/battle_video.py
+++ b/battle_video.py
@@ -1,0 +1,146 @@
+"""MAgent2 Battle 可视化 - 纯 numpy 渲染 + ffmpeg 合成视频
+
+不依赖 pygame，直接从环境底层数据画网格图。
+红队 = 红色，蓝队 = 蓝色，空地 = 白色。
+先保存 BMP 帧文件，再用 ffmpeg 合成 mp4。
+"""
+
+import os
+import struct
+import subprocess
+import numpy as np
+
+
+def write_bmp(filepath, img):
+    """写一个 24-bit BMP 文件 (不需要 PIL)"""
+    h, w, _ = img.shape
+    # BMP 行需要 4 字节对齐
+    row_size = (w * 3 + 3) & ~3
+    padding = row_size - w * 3
+    pixel_size = row_size * h
+
+    # BMP header (14 bytes) + DIB header (40 bytes)
+    header = struct.pack('<2sIHHI', b'BM', 54 + pixel_size, 0, 0, 54)
+    dib = struct.pack('<IiiHHIIiiII', 40, w, h, 1, 24, 0, pixel_size, 2835, 2835, 0, 0)
+
+    with open(filepath, 'wb') as f:
+        f.write(header)
+        f.write(dib)
+        # BMP 存储是从下到上，BGR 顺序
+        pad_bytes = b'\x00' * padding
+        for y in range(h - 1, -1, -1):
+            row = img[y]
+            # RGB -> BGR
+            f.write(row[:, ::-1].tobytes())
+            if padding:
+                f.write(pad_bytes)
+
+
+def render_frame(env, handles, map_size, cell_size=10):
+    """从环境底层数据手动渲染一帧 RGB 图像"""
+    h = w = map_size * cell_size
+    img = np.full((h, w, 3), 240, dtype=np.uint8)  # 浅灰背景
+
+    # 画网格线
+    for i in range(0, h, cell_size):
+        img[i, :] = [220, 220, 220]
+        img[:, i] = [220, 220, 220]
+
+    # 画墙壁 (深灰)
+    walls = env._get_walls_info()
+    for wx, wy in walls:
+        y0, y1 = wy * cell_size, (wy + 1) * cell_size
+        x0, x1 = wx * cell_size, (wx + 1) * cell_size
+        if 0 <= y0 < h and 0 <= x0 < w:
+            img[y0:y1, x0:x1] = [100, 100, 100]
+
+    # 红队和蓝队
+    colors = [(220, 50, 50), (50, 50, 220)]
+    for i, handle in enumerate(handles):
+        positions = env.get_pos(handle)
+        alive = env.get_alive(handle)
+        color = colors[i % 2]
+        for j in range(len(positions)):
+            if alive[j]:
+                px, py = positions[j]
+                y0 = py * cell_size + 1
+                x0 = px * cell_size + 1
+                y1 = y0 + cell_size - 2
+                x1 = x0 + cell_size - 2
+                if 0 <= y0 < h and 0 <= x0 < w:
+                    img[max(0,y0):min(h,y1), max(0,x0):min(w,x1)] = color
+
+    return img
+
+
+def run_battle_video(output_path="battle_video.mp4", map_size=45, max_cycles=200):
+    from magent2.environments.battle.battle import parallel_env as battle_parallel_env
+
+    env = battle_parallel_env(map_size=map_size, max_cycles=max_cycles)
+    observations, infos = env.reset()
+
+    inner_env = env.env
+    handles = env.handles
+
+    # 创建临时帧目录
+    frame_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_frames")
+    os.makedirs(frame_dir, exist_ok=True)
+
+    print(f"=== Battle Video Generation ===")
+    print(f"Map: {map_size}x{map_size}, max_cycles: {max_cycles}")
+
+    # 第一帧
+    frame = render_frame(inner_env, handles, map_size)
+    write_bmp(os.path.join(frame_dir, "frame_0000.bmp"), frame)
+    cycle = 0
+
+    while env.agents:
+        actions = {agent: env.action_space(agent).sample() for agent in env.agents}
+        observations, rewards, terminations, truncations, infos = env.step(actions)
+        cycle += 1
+
+        frame = render_frame(inner_env, handles, map_size)
+        write_bmp(os.path.join(frame_dir, f"frame_{cycle:04d}.bmp"), frame)
+
+        if cycle % 25 == 0:
+            red = sum(1 for a in env.agents if a.startswith("red"))
+            blue = sum(1 for a in env.agents if a.startswith("blue"))
+            print(f"  cycle {cycle:>4d}: red={red:>3d}, blue={blue:>3d}")
+
+    env.close()
+    print(f"\nSimulation done! {cycle + 1} frames saved.")
+
+    # ffmpeg 从图片序列合成视频
+    fps = 10
+    input_pattern = os.path.join(frame_dir, "frame_%04d.bmp")
+
+    cmd = [
+        "ffmpeg", "-y",
+        "-framerate", str(fps),
+        "-i", input_pattern,
+        "-c:v", "libx264",
+        "-pix_fmt", "yuv420p",
+        "-crf", "18",
+        output_path,
+    ]
+
+    print(f"Encoding video with ffmpeg ...")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode == 0:
+        size_kb = os.path.getsize(output_path) / 1024
+        duration = (cycle + 1) / fps
+        print(f"Done! {output_path} ({size_kb:.0f} KB, {duration:.1f}s)")
+    else:
+        print(f"ffmpeg error:\n{result.stderr}")
+
+    # 清理帧文件
+    import glob
+    for f in glob.glob(os.path.join(frame_dir, "*.bmp")):
+        os.remove(f)
+    os.rmdir(frame_dir)
+    print("Temp frames cleaned up.")
+
+
+if __name__ == "__main__":
+    run_battle_video()

--- a/docs/introduction/basic_usage.md
+++ b/docs/introduction/basic_usage.md
@@ -6,34 +6,71 @@ The environments in MAgent2 are implemented using [PettingZoo](https://github.co
 
 ```python
 from magent2.environments import battle_v4
-env = battle_v4.env(map_size=16, render_mode='human')
+env = battle_v4.env(map_size=45, render_mode='human')
 ```
 
 ## Interaction Workflow
 
+### AEC API (agents take turns)
+
 Interacting with the environment involves iterating through the agents, pulling environment information with the `last()` method, and sending actions through the `step()` method:
 
 ```python
+from magent2.environments import battle_v4
+
+env = battle_v4.env(map_size=45, max_cycles=300)
 env.reset()
+
 for agent in env.agent_iter():
     observation, reward, termination, truncation, info = env.last()
-    action = policy(observation, agent)
+    if termination or truncation:
+        action = None
+    else:
+        action = policy(observation, agent)
     env.step(action)
+
+env.close()
 ```
 
-## Demo
+### Parallel API (all agents act simultaneously)
 
-Run a demo using PettingZoo's [`random_demo`](https://github.com/Farama-Foundation/PettingZoo/blob/master/pettingzoo/utils/random_demo.py) function which implements this workflow with random policies:
+The Parallel API is faster because all agents choose actions at the same time:
+
 ```python
-from magent2.environments import battle_v4
-from pettingzoo.utils import random_demo
+from magent2.environments.battle.battle import parallel_env
 
-env = battle_v4.env(render_mode='human')
-random_demo(env, render=True, episodes=1)
+env = parallel_env(map_size=45, max_cycles=300)
+observations, infos = env.reset()
+
+while env.agents:
+    actions = {agent: env.action_space(agent).sample() for agent in env.agents}
+    observations, rewards, terminations, truncations, infos = env.step(actions)
+
+env.close()
 ```
 
-For more details on the API components, see the [PettingZoo Basic Usage page](https://pettingzoo.farama.org/content/basic_usage/).
+## Rendering
 
+### Human mode (pygame window)
+
+```python
+env = battle_v4.env(render_mode='human')
+```
+
+### Video generation (no display needed)
+
+You can render frames programmatically and encode them into a video with ffmpeg. See `battle_video.py` in the project root for a complete example that:
+
+1. Runs the battle simulation using the Parallel API
+2. Renders each frame as a grid image using numpy (red = red team, blue = blue team)
+3. Saves frames as BMP files and encodes them into MP4 with ffmpeg
+
+```bash
+python battle_video.py
+```
+
+Note: pygame's `rgb_array` render mode may hang on headless Windows environments. The `battle_video.py` script avoids this by rendering directly from the environment's internal state using numpy, without initializing pygame.
 
 ## Creating New Environments
+
 It is recommended to create MAgent2-based environments using the PettingZoo API in order to take advantage of the general multi-agent processing infrastructure and standardization available there. `magent2/environments/magent_env.py` contains classes to facilitate this integration. See the [reference environments](https://github.com/Farama-Foundation/MAgent2/tree/main/magent2/environments) included in MAgent2 for some examples. See the MAgent2 API documentation for further details about what functionalities MAgent2 exposes for environment creation.

--- a/magent2/__init__.py
+++ b/magent2/__init__.py
@@ -5,4 +5,4 @@ from magent2.render import Renderer
 # some alias
 GridWorld = gridworld.GridWorld
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"

--- a/magent2/c_lib.py
+++ b/magent2/c_lib.py
@@ -8,23 +8,37 @@ import platform
 
 
 def _load_lib():
-    """Load library in local."""
+    """Load the native magent shared library."""
     cur_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    lib_path = os.path.join(cur_path, "..", "venv", "Lib", "site-packages", "magent2")
+
     if platform.system() == "Darwin":
-        path_to_so_file = os.path.join(lib_path, "libmagent.dylib")
+        lib_names = ["libmagent.dylib"]
     elif platform.system() == "Linux":
-        path_to_so_file = os.path.join(lib_path, "libmagent.so")
+        lib_names = ["libmagent.so"]
     elif platform.system() == "Windows":
-        path_to_so_file = os.path.join(lib_path, "magent.dll")
+        lib_names = ["magent.dll"]
     else:
-        raise BaseException("unsupported system: " + platform.system())
+        raise OSError("unsupported system: " + platform.system())
 
-    if not os.path.exists(path_to_so_file):
-        raise FileNotFoundError(f"Could not find the DLL file at: {path_to_so_file}")
+    # Also search for .pyd files (setuptools editable installs on Windows)
+    import glob
 
-    lib = ctypes.CDLL(path_to_so_file, ctypes.RTLD_GLOBAL)
-    return lib
+    pyd_files = glob.glob(os.path.join(cur_path, "libmagent*.pyd"))
+    lib_names.extend(os.path.basename(f) for f in pyd_files)
+
+    search_paths = []
+    for lib_name in lib_names:
+        search_paths.append(os.path.join(cur_path, lib_name))
+        search_paths.append(os.path.join(cur_path, "build", lib_name))
+
+    for path in search_paths:
+        if os.path.exists(path):
+            return ctypes.CDLL(path, ctypes.RTLD_GLOBAL)
+
+    raise FileNotFoundError(
+        f"Could not find native magent library. Searched:\n"
+        + "\n".join(f"  - {p}" for p in search_paths)
+    )
 
 
 def as_float_c_array(buf):

--- a/magent2/environments/magent_env.py
+++ b/magent2/environments/magent_env.py
@@ -106,7 +106,9 @@ class magent_parallel_env(ParallelEnv):
 
     def seed(self, seed=None):
         if seed is None:
-            _, seed = seeding.np_random()
+            np_random, seed = seeding.np_random()
+        else:
+            np_random, seed = seeding.np_random(seed)
         self.env.set_seed(seed)
 
     def _calc_obs_shapes(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,23 +8,22 @@ build-backend = "setuptools.build_meta"
 name = "magent2"
 description = "Multi-Agent Reinforcement Learning environments with very large numbers of agents."
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI"]
 classifiers = [
-    "Development Status :: 4 - Beta",  # change to `5 - Production/Stable` when ready
+    "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    'Intended Audience :: Science/Research',
-    'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    "Programming Language :: Python :: 3.12",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "numpy>=1.21.0,<2.0",
+    "numpy>=1.21.0",
     "pygame>=2.1.0",
     "pettingzoo>=1.23.1",
 ]
@@ -59,7 +58,7 @@ exclude = ["**/__pycache__"]
 strict = []
 
 typeCheckingMode = "basic"
-pythonVersion = "3.8"
+pythonVersion = "3.10"
 pythonPlatform = "All"
 enableTypeIgnoreComments = true
 

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,11 @@
 import os
 import platform
+import shutil
 import subprocess
-from subprocess import check_output
 
 import setuptools
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
-
-
-###
-# Build process:
-# cmake .
-# make -j threads
-# move libmagent -> build/
-###
 
 
 def get_version():
@@ -29,10 +21,10 @@ def get_version():
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir, config=[]):
+    def __init__(self, name, sourcedir, config=None):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
-        self.config = config
+        self.config = config or []
 
 
 class CMakeBuild(build_ext):
@@ -44,7 +36,7 @@ class CMakeBuild(build_ext):
                 "CMake must be installed to build the extensions: %s"
                 % ", ".join(ext.name for ext in self.extensions)
             )
-        cfg = "Debug" if self.debug else "Release"
+        cfg = "Release"
         for ext in self.extensions:
             if not os.path.exists(self.build_temp):
                 os.makedirs(self.build_temp)
@@ -55,9 +47,7 @@ class CMakeBuild(build_ext):
                 f"-DCMAKE_BUILD_TYPE={cfg}",
                 f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}",
                 f"-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}",
-                "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}".format(
-                    cfg.upper(), self.build_temp
-                ),
+                f"-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{cfg.upper()}={self.build_temp}",
             ]
 
             make_location = os.path.abspath(self.build_temp)
@@ -65,51 +55,27 @@ class CMakeBuild(build_ext):
             subprocess.check_call(
                 ["cmake", ext.sourcedir] + cmake_config_args, cwd=make_location
             )
-            print(ext.name)
+
+            subprocess.check_call(
+                ["cmake", "--build", ".", "--config", cfg],
+                cwd=make_location,
+            )
+
+            # CMake produces magent.dll / libmagent.so / libmagent.dylib,
+            # but setuptools expects a .pyd file on Windows. Copy the built
+            # shared library to the path setuptools expects.
+            ext_fullpath = self.get_ext_fullpath(ext.name)
+            ext_fulldir = os.path.dirname(ext_fullpath)
             if platform.system() == "Windows":
-                str(subprocess.check_output(["cd"], shell=True).decode()).strip()
-                # subprocess.check_call(["dir"], shell=True)
+                built_lib = os.path.join(extdir, "magent.dll")
+            elif platform.system() == "Darwin":
+                built_lib = os.path.join(extdir, "libmagent.dylib")
             else:
-                subprocess.check_call(["pwd"])
-                print(extdir)
-                subprocess.check_call(["ls"])
+                built_lib = os.path.join(extdir, "libmagent.so")
 
-            # lib_ext = ""
-            # lib_name = ""
-
-            if platform.system() == "Darwin":
-                # lib_ext = ".dylib"
-                # lib_name = "libmagent"
-                thread_num = check_output(["sysctl", "-n", "hw.ncpu"], encoding="utf-8")
-                subprocess.check_call(
-                    ["make", "-C", make_location, "-j", str(thread_num).rstrip()],
-                    cwd=extdir,
-                )
-            elif platform.system() == "Linux":
-                # lib_ext = ".so"
-                # lib_name = "libmagent"
-                thread_num = check_output(["nproc"], encoding="utf-8")
-                subprocess.check_call(
-                    ["make", "-C", make_location, "-j", str(thread_num).rstrip()],
-                    cwd=extdir,
-                )
-            elif platform.system() == "Windows":
-                # lib_ext = ".dll"
-                # lib_name = "magent"
-                thread_num = 1
-                # cmake --build . --target ALL_BUILD --config Release
-                subprocess.check_call(
-                    ["cmake", "--build", ".", "--target", "ALL_BUILD", "--config", cfg],
-                    cwd=make_location,
-                    shell=True,
-                )
-            # build_res_dir = extdir + "/magent/build/"
-            # if not os.path.exists(build_res_dir):
-            #     os.makedirs(build_res_dir)
-            # lib_name = extdir + "/libmagent" + lib_ext
-            # subprocess.check_call(
-            #     ["mv", lib_name, build_res_dir]
-            # )
+            if os.path.exists(built_lib):
+                os.makedirs(ext_fulldir, exist_ok=True)
+                shutil.copy2(built_lib, ext_fullpath)
 
 
 setuptools.setup(

--- a/src/gridworld/Map.cc
+++ b/src/gridworld/Map.cc
@@ -3,9 +3,9 @@
  * \brief The map for the game engine
  */
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <iostream>
-#include <assert.h>
+#include <cassert>
 #include "Map.h"
 #include "GridWorld.h"
 

--- a/src/gridworld/Range.h
+++ b/src/gridworld/Range.h
@@ -7,7 +7,7 @@
 #define MAGNET_GRIDWORLD_RANGE_H
 
 #include <cstdio>
-#include <tgmath.h>
+#include <cmath>
 #include <cstring>
 
 namespace magent {
@@ -28,8 +28,8 @@ public:
         dy = new int[width * height];
 
         memcpy(is_in_range, other.is_in_range, sizeof(bool) * width * height);
-        memcpy(dx, other.dx, sizeof(bool) * width * height);
-        memcpy(dy, other.dy, sizeof(bool) * width * height);
+        memcpy(dx, other.dx, sizeof(int) * width * height);
+        memcpy(dy, other.dy, sizeof(int) * width * height);
     }
 
     ~Range() {

--- a/src/gridworld/RewardEngine.cc
+++ b/src/gridworld/RewardEngine.cc
@@ -3,7 +3,7 @@
  * \brief implementation of reward description
  */
 
-#include "assert.h"
+#include <cassert>
 
 #include "RewardEngine.h"
 #include "GridWorld.h"


### PR DESCRIPTION
- Fix c_lib.py: replace hardcoded venv path with automatic library discovery
- Fix CMakeLists.txt: separate MSVC/GCC flags, use CMAKE_CXX_STANDARD
- Fix setup.py: remove deprecated self.debug, unify cross-platform cmake build
- Fix Range.h: sizeof(bool) -> sizeof(int) in copy constructor (data corruption bug)
- Fix C++ headers: tgmath.h -> cmath, stdlib.h -> cstdlib, assert.h -> cassert
- Fix magent_env.py: update deprecated seeding.np_random() API
- Update pyproject.toml: Python >=3.10, remove numpy <2.0 upper bound
- Update CI: Python 3.10-3.12 matrix, upgrade actions to v4/v5
- Update pre-commit: pyupgrade --py310-plus
- Update README and docs with modern usage examples
- Add battle_demo.py and battle_video.py examples
- Bump version to 0.4.0

Tested with Python 3.11, numpy 2.3, gymnasium 1.2.3, pettingzoo 1.25, pygame 2.6.1

Fixes #63, #59, #57, #54, #53