### PR TITLE
Enable docs versioning on magent2.farama.org

### DIFF
--- a/.github/workflows/build-docs-version.yml
+++ b/.github/workflows/build-docs-version.yml
@@ -1,14 +1,16 @@
-name: Deploy Docs
+name: Build release documentation website
+
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v?*.*.*'
 
 permissions:
   contents: write
 
 jobs:
   docs:
-    name: Generate Website
+    name: Generate Website for new version
     runs-on: ubuntu-latest
 
     steps:
@@ -44,9 +46,18 @@ jobs:
       - name: Remove .doctrees
         run: rm -r _build/.doctrees
 
-      - name: Upload to GitHub Pages
+      - name: Upload to GitHub Pages (versioned)
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: _build
-          target-folder: main
+          target-folder: ${{ github.ref_name }}
           clean: false
+
+      - name: Upload to GitHub Pages (latest at root)
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ !contains(github.ref_name, 'a') }}
+        with:
+          folder: _build
+          clean-exclude: |
+            *.*.*/
+            main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,10 @@ html_theme_options = {
     "light_logo": "img/magent2.svg",
     "dark_logo": "img/magent2-white.svg",
     "gtag": "G-07SGW5KKJF",
+    "versioning": True,
+    "source_repository": "https://github.com/Farama-Foundation/MAgent2/",
+    "source_branch": "main",
+    "source_directory": "docs/",
 }
 html_context: Dict[str, Any] = {}
 html_context["conf_py_path"] = "/docs/"


### PR DESCRIPTION
## Problem

magent2.farama.org has **no version selector at all** — unlike the other Farama doc sites. Three things are missing:

1. `conf.py`'s `html_theme_options` has neither `"versioning": True` nor `source_repository`, so the Celshast `furo` theme never injects the selector script (it gates on `theme_versioning == True and theme_source_repository`).
2. `gh-pages.yml` deploys the build to the `gh-pages` **root** (no `target-folder`), so there's no `/main/` directory for the selector menu to load from.
3. There is no release workflow, so no `/<version>/` folders are ever deployed.

## Change (mirrors gymnasium.farama.org)

- **`conf.py`** — add `"versioning": True` plus `source_repository` / `source_branch` / `source_directory`. Verified with a minimal furo build that this injects the selector and derives `Farama-Foundation/MAgent2` from `source_repository`.
- **`gh-pages.yml`** — deploy main under `target-folder: main` with `clean: false`.
- **`build-docs-version.yml`** (new) — on `v?*.*.*` tags, reuse this repo's own build steps (`docs/scripts/gen_mds.py`, the cmake install + `rm -rf magent2` shadow-avoidance, `sphinx-build -b dirhtml`, the 404 steps), then deploy to `/<tag>/` and copy the latest non-alpha release to root.

## Notes

- **No historical back-fill** — versions accumulate forward from the next release, the same way Gymnasium adopted versioning. Until the next release the dropdown shows just `main`.
- After merge, the next release populates the site root; until then the bare root keeps serving the previous build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)