### PR TITLE
Add manual docs version-deploy workflow

### DIFF
--- a/.github/workflows/manual-build-docs-version.yml
+++ b/.github/workflows/manual-build-docs-version.yml
@@ -1,0 +1,78 @@
+name: Manual Docs Versioning
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+          description: 'Documentation version to create'
+          required: true
+      commit:
+          description: 'Commit used to build the Documentation version'
+          required: false
+      latest:
+          description: 'Latest version'
+          type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    name: Generate Website for new version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        if: inputs.commit == ''
+
+      - uses: actions/checkout@v4
+        if: inputs.commit != ''
+        with:
+          ref: ${{ inputs.commit }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Install cmake
+        run: python -m pip install --upgrade pip && pip install cmake setuptools wheel
+
+      - name: Install package
+        run: pip install .
+
+      - name: Build Envs Docs
+        run: python docs/scripts/gen_mds.py
+
+      - name: Remove source package
+        run: rm -rf magent2
+
+      - name: Build
+        run: sphinx-build -b dirhtml -v docs _build
+
+      - name: Move 404
+        run: mv _build/404/index.html _build/404.html
+
+      - name: Update 404 links
+        run: python docs/scripts/move404.py _build/404.html
+
+      - name: Remove .doctrees
+        run: rm -r _build/.doctrees
+
+      - name: Upload to GitHub Pages (versioned)
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: _build
+          target-folder: ${{ inputs.version }}
+          clean: false
+
+      - name: Upload to GitHub Pages (latest at root)
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: inputs.latest
+        with:
+          folder: _build
+          clean-exclude: |
+            *.*.*/
+            main


### PR DESCRIPTION
Follow-up to #74. Adds the manual version-deploy workflow that the other Farama doc repos have (e.g. momaland, shimmy) but magent2 was missing.

`workflow_dispatch` with inputs `version` (folder name), `commit` (ref to build from, optional), and `latest` (also copy to the site root). It reuses this repo's own docs build steps and deploys to `/<version>/`, plus the root when `latest` is set.

## Why this is needed now

After #74, main deploys to `/main/` and the bare site root (`magent2.farama.org/`) is no longer updated, so it still serves the old pre-versioning build with no selector. This workflow is the mechanism to repopulate the root with a real release.

Note: the existing tags (`0.3.0`–`0.3.4`) predate the versioning config, so building one of them as-tagged would produce a root **without** the selector. To get a selector-enabled root, deploy a build that includes the versioning flag — i.e. either cut a new release from `main` (handled automatically by `build-docs-version.yml`), or run this workflow against a ref that has the flag applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)