### PR TITLE
render: pump event queue to prevent window freeze on focus loss

### DIFF
--- a/magent2/render.py
+++ b/magent2/render.py
@@ -329,6 +329,10 @@ class Renderer:
         new_observation = np.copy(observation)
         del observation
         if self.mode == "human":
+            # Drain the event queue every frame. Without this the OS considers
+            # the window unresponsive and it freezes (e.g. when it loses focus).
+            pygame.event.pump()
+            pygame.event.clear()
             pygame.display.flip()
         return (
             np.transpose(new_observation, axes=(1, 0, 2))


### PR DESCRIPTION
# Description

Fixes #15.

**Does the issue still exist?** Yes — the human-mode renderer never processes the pygame event queue (there is no `event.pump`/`event.get` anywhere in `render.py`). When the queue is not drained the OS marks the window as unresponsive, which is what causes the freeze the issue describes when the window loses focus.

This adds `pygame.event.pump()` + `pygame.event.clear()` on every rendered frame in human mode, so the window stays responsive.

## Verification

With a battle env in `render_mode="human"`, I posted events into the queue and confirmed they are drained to 0 after each `render()` call, and rendering runs without error.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
