### PR TITLE
battle: document that the engine grants KILL_REWARD directly (re: #61)

### DIFF
--- a/magent2/environments/battle/battle.py
+++ b/magent2/environments/battle/battle.py
@@ -220,6 +220,13 @@ def get_config(
         gw.Event(b, "attack", a), receiver=b, value=attack_opponent_reward
     )
 
+    # NOTE: the KILL_REWARD (the "kill_reward" agent-type option above) is
+    # granted directly by the C++ engine: Map::do_attack returns the victim's
+    # kill_reward to the killer (see src/gridworld/Map.cc / GridWorld.cc). No
+    # explicit `Event(a, "kill", b)` reward rule is added here on purpose --
+    # doing so would reward kills *twice*. This differs from combined_arms,
+    # which grants the kill reward solely through an explicit rule and does not
+    # set the "kill_reward" option.
     return cfg
 
 

--- a/magent2/environments/battle/battle.py
+++ b/magent2/environments/battle/battle.py
@@ -70,6 +70,12 @@ Reward is given as:
 
 If multiple options apply, rewards are added.
 
+The kill reward is granted by the underlying C++ engine rather than by a reward
+rule: when an attack reduces an agent's HP to zero, the engine returns the dead
+agent's `kill_reward` to its killer. This is why, unlike `combined_arms`, this
+environment does not register an explicit `Event(a, "kill", b)` rule -- adding
+one would pay out the kill reward twice.
+
 #### Observation space
 
 The observation space is a 13x13 map with the below channels (in order):

--- a/magent2/environments/battlefield/battlefield.py
+++ b/magent2/environments/battlefield/battlefield.py
@@ -71,6 +71,12 @@ Reward is given as:
 
 If multiple options apply, rewards are added.
 
+The kill reward is granted by the underlying C++ engine rather than by a reward
+rule: when an attack reduces an agent's HP to zero, the engine returns the dead
+agent's `kill_reward` to its killer. This is why, unlike `combined_arms`, this
+environment does not register an explicit `Event(a, "kill", b)` rule -- adding
+one would pay out the kill reward twice.
+
 #### Observation space
 
 The observation space is a 13x13 map with the below channels (in order):


### PR DESCRIPTION
# Description

Re: #61.

## Investigation

The issue reports that `KILL_REWARD` in Battle/Battlefield is "plugged into the options dict and used for the reward range, but a rule is never created for it to get rewarded to agents (unlike combined_arms)".

I traced this through the C++ engine and it turns out **the kill reward is already granted** — the `kill_reward` agent-type option is not dead config:

- `src/gridworld/Map.cc` — `Map::do_attack(...)` returns `obj->get_type().kill_reward` (the victim's `kill_reward`) when the attack kills the target.
- `src/gridworld/GridWorld.cc` — the attack handler does `reward = map.do_attack(...)` then `agent->add_reward(reward + attack_penalty)`.

So in Battle/Battlefield the killer already receives `+KILL_REWARD`, and the reward range that includes it is correct.

### Reproduction (current `main`, built locally)

Two adjacent opposing agents, one lands the killing blow (`step_recover=0`, one-shot damage), measuring the killer's reward on the killing step:

| `kill_reward` option | explicit `Event(a,"kill",b)` rule | killer reward on kill |
|---|---|---|
| 0 | none | `-0.105` (attack + step penalties only) |
| **5** | none | **`+4.895`** ⇐ Battle's current setup |
| 0 | 5 | `+4.895` |
| 5 | 5 | `+9.895` ⇐ **double-counted** |

Battle sets the `kill_reward` option (row 2) and combined_arms uses only the explicit rule (row 3); **both grant exactly one kill reward**. Adding an explicit kill rule to Battle *on top of* its existing option would double the reward (row 4).

## Change

This is therefore **not a behavior bug** — no reward change is made. I've added a comment in `battle.py` documenting that the engine grants `kill_reward` directly, so the difference from combined_arms isn't later "fixed" into a double reward by mistake. `api_test` passes for both `battle_v4` and `battlefield_v5` (behavior unchanged).

I'd suggest #61 can be closed as working-as-intended once this (or an equivalent note) lands.

## Type of change

- Documentation / clarification (no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
