### PR TITLE
docs: document minimap_mode channels for adversarial_pursuit

### DIFF
--- a/magent2/environments/adversarial_pursuit/adversarial_pursuit.py
+++ b/magent2/environments/adversarial_pursuit/adversarial_pursuit.py
@@ -71,11 +71,14 @@ feature | number of channels
 obstacle/off the map| 1
 my_team_presence| 1
 my_team_hp| 1
+my_team_minimap(minimap_mode=True)| 1
 other_team_presence| 1
 other_team_hp| 1
+other_team_minimap(minimap_mode=True)| 1
 binary_agent_id(extra_features=True)| 10
 one_hot_action(extra_features=True)| 9/Prey,13/Predator
 last_reward(extra_features=True)| 1
+agent_position(minimap_mode=True)| 2
 
 ### State space
 


### PR DESCRIPTION
# Description

Fixes #43.

The Adversarial Pursuit docs describe the `minimap_mode` argument but its observation-space table never listed the channels that `minimap_mode=True` actually adds, so the argument looked like it did nothing. In reality the environment augments the observation just like the other scenarios (e.g. `battle`).

This adds the missing rows to the observation-space table, matching `battle`'s documented convention:

- `my_team_minimap(minimap_mode=True)` | 1
- `other_team_minimap(minimap_mode=True)` | 1
- `agent_position(minimap_mode=True)` | 2

## Verification

Checked the real observation shapes on a locally built `magent2`:

| minimap_mode | extra_features | predator | prey |
|---|---|---|---|
| False | False | (10,10,**5**) | (9,9,**5**) |
| True  | False | (10,10,**9**) | (9,9,**9**) |

Base 5 channels → 9 with `minimap_mode=True` (i.e. +4: the two `*_minimap` channels plus the 2 `agent_position` channels), consistent with the updated table.

## Type of change

- Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
