### PR TITLE
render: speed up pygame init on the human path

### DIFF
--- a/magent2/render.py
+++ b/magent2/render.py
@@ -94,8 +94,8 @@ class Renderer:
         self.handles = self.env.get_handles()
         base_resolution = (map_size * 8, map_size * 8 + 16)
         if mode == "human":
-            pygame.init()
             pygame.display.init()
+            pygame.font.init()
             infoObject = pygame.display.Info()
             screen_size = (infoObject.current_w - 50, infoObject.current_h - 50)
             self.resolution = resolution = np.min(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,47 @@
+"""Tests for :mod:`magent2.render`."""
+
+import os
+
+
+# Run headless so the renderer can be constructed in CI without a real
+# display or audio device. SDL reads these variables when its subsystems are
+# initialized, so they must be set before pygame initializes anything.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "hide")
+
+import pygame  # noqa: E402
+
+from magent2.render import Renderer  # noqa: E402
+
+
+class _FakeEnv:
+    """Minimal stand-in for a GridWorld env, enough to build a Renderer."""
+
+    def get_handles(self):
+        return []
+
+
+def test_human_mode_only_initializes_needed_subsystems():
+    """The human render path must init only the display and font subsystems.
+
+    ``pygame.init()`` eagerly starts every subsystem (audio/mixer, joystick,
+    etc.), which MAgent2 never uses and which is slow to enumerate on some
+    platforms. The renderer only needs ``display`` (for the window) and
+    ``font`` (for the ``SysFont`` banners), so those are the only subsystems
+    that should be initialized. See issue #68.
+    """
+    # Reset any global pygame state left over by other tests so the assertions
+    # reflect exactly what constructing the Renderer initializes.
+    pygame.quit()
+
+    renderer = Renderer(_FakeEnv(), map_size=10, mode="human")
+    try:
+        assert pygame.display.get_init(), "display subsystem should be initialized"
+        assert pygame.font.get_init(), "font subsystem should be initialized"
+        assert (
+            pygame.mixer.get_init() is None
+        ), "audio/mixer subsystem should NOT be initialized on the render path"
+    finally:
+        renderer.close()
+        pygame.quit()


### PR DESCRIPTION
## Description

`Renderer.__init__`'s `mode == "human"` branch called the full `pygame.init()`, which eagerly starts **every** pygame subsystem — including audio/mixer and joystick, which MAgent2 never uses. Enumerating the audio device in particular is slow on some platforms (notably Windows).

This initializes only the subsystems the renderer actually needs:

- `pygame.display.init()` (kept) — for the window
- `pygame.font.init()` (added) — for the `SysFont` banners created immediately after

This mirrors the `rgb_array` branch, which already initializes only `font`.

```diff
         if mode == "human":
-            pygame.init()
             pygame.display.init()
+            pygame.font.init()
```

## Motivation and context

Closes #68. The same optimization has already been merged in sibling Farama repos: Gymnasium #1586 and PettingZoo #1343.

## How it was tested

Added a headless regression test (`tests/test_render.py`) that builds a real `Renderer(mode="human")` and asserts the display and font subsystems are initialized while audio/mixer is **not** (`pygame.mixer.get_init() is None`). It sets `SDL_VIDEODRIVER`/`SDL_AUDIODRIVER=dummy` so it runs on display-less CI runners.

- The new test **fails** on the pre-fix code (`assert (44100, -16, 2) is None`) and **passes** after the change — confirming it is a real, non-vacuous regression test.
- Full suite passes: `pytest tests` → **3 passed**.
- Lint clean with the repo's pinned pre-commit tools: black 23.3.0, isort 5.12.0, flake8 6.0.0.

Measured on Linux (pygame-ce 2.5.7), the human render path, before vs after:

| subsystem | before (`pygame.init()`) | after (`display.init()` + `font.init()`) |
|---|---|---|
| display | initialized | initialized |
| font | initialized | initialized |
| mixer | `(44100, -16, 2)` | `None` |
| joystick | initialized | not initialized |
