### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MAgent2/security/code-scanning/5](https://github.com/Farama-Foundation/MAgent2/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/build-test-publish.yml` right after the `on:` trigger section (before `jobs:`).  
Best minimal safe baseline per CodeQL is:

- `contents: read`

This preserves existing functionality for checkout/artifact/test/build steps that only need read access to repository contents. If the unseen `publish` job requires additional write scopes (for example `packages: write` or `id-token: write` for trusted publishing), those should be added in that job specifically; but based only on the shown snippet, the required fix is to ensure explicit permissions exist, and `contents: read` is the minimal compliant starting point.

No imports, methods, or dependencies are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
