### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
   push:
     branches: [main]
+permissions:
+  contents: read
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MAgent2/security/code-scanning/3](https://github.com/Farama-Foundation/MAgent2/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix here: define workflow-level permissions right after the `on` block (before `jobs`) with `contents: read`. This preserves existing functionality (checkout and pre-commit execution) while preventing unnecessary write scopes now and in future repo/org setting changes.

Edit only `.github/workflows/pre-commit.yml`:
- Insert:
  - `permissions:`
  - `  contents: read`
- No imports, methods, or dependencies are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
