### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -6,6 +6,9 @@
 
 name: Build, test and publish Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/MAgent2/security/code-scanning/1](https://github.com/Farama-Foundation/MAgent2/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build-test-publish.yml`, directly under `name` (before `on:`).  
For this workflow snippet, the safest minimal baseline is:

- `contents: read`

This preserves existing behavior for checkout and artifact operations while enforcing least privilege for `GITHUB_TOKEN` by default. If hidden jobs later require elevated scopes (e.g., package publish), those should be added explicitly at the relevant job(s), but based only on the shown snippet, root-level `contents: read` is the best non-breaking fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
