### PR TITLE
fix(ci): remove duplicated permission declaration

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -6,9 +6,6 @@
 
 name: Build, test and publish Python package
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Fix CIs on main. CodeQL double-applied the permissions patch.